### PR TITLE
Add BannerAdWidget to multiple screens for ad display

### DIFF
--- a/lib/screens/automation_script_screen.dart
+++ b/lib/screens/automation_script_screen.dart
@@ -92,6 +92,8 @@ class AutomationScriptScreenState
                     : null,
               ),
               const SizedBox(height: 24),
+              const BannerAdWidget(),
+            const SizedBox(height: 14),
               ElevatedButton(
                 onPressed: _isSubmitting ? null : _submitScriptRequest,
                 style: ElevatedButton.styleFrom(
@@ -107,6 +109,8 @@ class AutomationScriptScreenState
                       )
                     : const Text('Generate Script'),
               ),
+              
+            const SizedBox(height: 14),
             const NativeAdWidget(),
             ],
           ),

--- a/lib/screens/chatbot_screen.dart
+++ b/lib/screens/chatbot_screen.dart
@@ -542,7 +542,7 @@ Widget _suggestionMenu(BuildContext context) {
           label: 'Photo Analyzer',
           icon: Icons.camera_alt_outlined,
           customGradient: LinearGradient(
-            colors: [Colors.deepOrange.shade400, Colors.amber.shade400],
+            colors: [Colors.deepOrange.shade400, const Color.fromARGB(255, 160, 88, 6)],
           ),
           onTap: () {
             // Already in chatbot; just open analyzer

--- a/lib/screens/compatibility_report.dart
+++ b/lib/screens/compatibility_report.dart
@@ -74,6 +74,7 @@ void showReportDialog(BuildContext context, CompatibilityReport report,
               ),
             ],
           ),
+          
           content: SizedBox(
             width: double.maxFinite,
             child: SingleChildScrollView(
@@ -81,6 +82,8 @@ void showReportDialog(BuildContext context, CompatibilityReport report,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  const BannerAdWidget(),
+                  const SizedBox(height: 12),
                   _buildHarmonyCard(context, report),
                   const SizedBox(height: 16),
                   ...sections.entries.map((entry) {

--- a/lib/screens/photo_analysis_result_screen.dart
+++ b/lib/screens/photo_analysis_result_screen.dart
@@ -91,6 +91,8 @@ class _PhotoAnalysisResultScreenState
         children: [
           _header(context),
           const SizedBox(height: 12),
+          const BannerAdWidget(),
+          const SizedBox(height: 12),
           _thumbnail(context),
           const SizedBox(height: 16),
           _summaryCard(context),
@@ -108,9 +110,12 @@ class _PhotoAnalysisResultScreenState
           _waterGuessesCard(context),
           const SizedBox(height: 16),
           _howAquaPiHelps(context),
-          const SizedBox(height: 24),
+          const SizedBox(height: 14),
+          const BannerAdWidget(),
+          const SizedBox(height: 14),
           Row(
             children: [
+              const SizedBox(height: 12),
               Expanded(
                 child: ElevatedButton.icon(
                   onPressed: _regenerating ? null : _regenerate,
@@ -505,15 +510,28 @@ class _PhotoAnalysisResultScreenState
   Widget _howAquaPiHelps(BuildContext context) {
     return Card(
       elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: MarkdownBody(
-          data: widget.result.howAquaPiHelps,
-          selectable: true,
-          onTapLink: (text, href, title) {
-            if (href != null) launchUrl(Uri.parse(href));
-          },
-        ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
+            child: Text('How AquaPi Helps',
+                style: Theme.of(context)
+                    .textTheme
+                    .titleLarge
+                    ?.copyWith(fontWeight: FontWeight.bold)),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: MarkdownBody(
+              data: widget.result.howAquaPiHelps,
+              selectable: true,
+              onTapLink: (text, href, title) {
+                if (href != null) launchUrl(Uri.parse(href));
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/photo_analysis_screen.dart
+++ b/lib/screens/photo_analysis_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'package:fish_ai/widgets/ad_component.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -176,6 +177,8 @@ class PhotoAnalysisScreenState extends ConsumerState<PhotoAnalysisScreen> {
                 ),
                 textAlign: TextAlign.center,
               ),
+              const BannerAdWidget(),
+              const SizedBox(height: 12),
             ElevatedButton.icon(
               onPressed: (_imageBytes == null || _isSubmitting) ? null : _submit,
               icon: _isSubmitting

--- a/lib/screens/stocking_report_screen.dart
+++ b/lib/screens/stocking_report_screen.dart
@@ -293,6 +293,8 @@ class _RecommendationTabView extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
       children: [
+        const BannerAdWidget(),
+        const SizedBox(height: 16),
         Text(
           report.title,
           style: theme.textTheme.headlineSmall?.copyWith(
@@ -485,6 +487,33 @@ class _RecommendationTabView extends StatelessWidget {
               selected: false,
             );
           }).toList(),
+        ),
+
+        const SizedBox(height: 16),
+        const BannerAdWidget(),
+        const SizedBox(height: 16),
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: cs.errorContainer.withOpacity(0.3),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: cs.error.withOpacity(0.5)),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(Icons.warning_amber_rounded, size: 18, color: cs.error),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  'AI can make mistakes. Please verify the information provided in this report before making any stocking decisions.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: cs.onSurface,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
         
         // Calculation Breakdown for tank-based recommendations

--- a/lib/screens/water_parameter_analysis_screen.dart
+++ b/lib/screens/water_parameter_analysis_screen.dart
@@ -1,3 +1,4 @@
+import 'package:fish_ai/widgets/ad_component.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/chat_provider.dart';
@@ -161,6 +162,8 @@ class TankVolumeCalculatorState
                 maxLines: 3,
               ),
               const SizedBox(height: 24),
+              const BannerAdWidget(),
+              const SizedBox(height: 12),
               ElevatedButton(
                 onPressed: _isSubmitting ? null : _submitAnalysis,
                 style: ElevatedButton.styleFrom(


### PR DESCRIPTION
Inserted BannerAdWidget and spacing in several screens including automation script, chatbot, compatibility report, photo analysis, stocking report, and water parameter analysis screens to display banner ads. Also improved the 'How AquaPi Helps' card with a title in the photo analysis result screen and added a warning message in the stocking report screen. These changes enhance monetization and user awareness across the app.